### PR TITLE
feat: Add Chat Manager

### DIFF
--- a/src/framework/bot.ts
+++ b/src/framework/bot.ts
@@ -1,4 +1,5 @@
 import { Client, ClientOptions, Events } from "discord.js";
+import { ChatManager, ChatManagerOptions } from "./chatManager/index.js";
 import {
   CommandManager,
   CommandManagerOptions,
@@ -13,6 +14,7 @@ export type BotOptions = {
   loggerOptions?: LoggerOptions;
   prefixManagerOptions: PrefixManagerOptions;
   commandManagerOptions: CommandManagerOptions;
+  chatManagerOptions: ChatManagerOptions;
 };
 
 export class Bot<Ready extends boolean = boolean> {
@@ -20,6 +22,7 @@ export class Bot<Ready extends boolean = boolean> {
   public readonly logger: Logger;
   public readonly prefixManager: PrefixManager;
   public readonly commandManager: CommandManager;
+  public readonly chatManager: ChatManager;
   public readonly eventManager: EventManager;
 
   private ready: boolean = false;
@@ -34,6 +37,10 @@ export class Bot<Ready extends boolean = boolean> {
     this.commandManager = new CommandManager(
       this as Bot<true>,
       options.commandManagerOptions,
+    );
+    this.chatManager = new ChatManager(
+      this as Bot<true>,
+      options.chatManagerOptions,
     );
     this.eventManager = new EventManager(this as Bot<true>);
   }
@@ -52,6 +59,7 @@ export class Bot<Ready extends boolean = boolean> {
     });
     await Promise.all([
       this.commandManager.loadCommands(),
+      this.chatManager.loadChatParticipants(),
       this.client.login(token),
       clientReadyPromise,
     ]);
@@ -62,6 +70,7 @@ export class Bot<Ready extends boolean = boolean> {
 
     await this.commandManager.registerCommandsOnDiscord();
     this.commandManager.startCommandHandlers();
+    this.chatManager.startChatHandler();
 
     this.ready = true;
     this.logger.info(`Ready! Logged in as ${this.client.user.tag}`);

--- a/src/framework/bot.ts
+++ b/src/framework/bot.ts
@@ -6,16 +6,19 @@ import {
 import { LichobiError } from "./errors.js";
 import { EventManager } from "./eventManager/index.js";
 import { Logger, LoggerOptions } from "./logger.js";
+import { PrefixManager, PrefixManagerOptions } from "./prefixManager/index.js";
 
 export type BotOptions = {
   clientOptions: ClientOptions;
   loggerOptions?: LoggerOptions;
+  prefixManagerOptions: PrefixManagerOptions;
   commandManagerOptions: CommandManagerOptions;
 };
 
 export class Bot<Ready extends boolean = boolean> {
   public readonly client: Client<Ready>;
   public readonly logger: Logger;
+  public readonly prefixManager: PrefixManager;
   public readonly commandManager: CommandManager;
   public readonly eventManager: EventManager;
 
@@ -24,6 +27,10 @@ export class Bot<Ready extends boolean = boolean> {
   constructor(options: BotOptions) {
     this.client = new Client(options.clientOptions);
     this.logger = new Logger(options.loggerOptions);
+    this.prefixManager = new PrefixManager(
+      this as Bot<true>,
+      options.prefixManagerOptions,
+    );
     this.commandManager = new CommandManager(
       this as Bot<true>,
       options.commandManagerOptions,

--- a/src/framework/chatManager/chatManager.ts
+++ b/src/framework/chatManager/chatManager.ts
@@ -1,0 +1,72 @@
+import { Events } from "discord.js";
+import { Bot } from "../bot.js";
+import { LichobiEvent } from "../event/index.js";
+import { ChatRegistry } from "./chatRegistry.js";
+
+export type ChatManagerOptions = {
+  chatParticipantsFolder: string;
+};
+
+export class ChatManager {
+  private readonly bot: Bot<true>;
+  private readonly chatParticipantsFolder: string;
+  public readonly participants: ChatRegistry;
+
+  constructor(bot: Bot<true>, options: ChatManagerOptions) {
+    this.bot = bot;
+    this.participants = new ChatRegistry(bot);
+    this.chatParticipantsFolder = options.chatParticipantsFolder;
+  }
+
+  public async loadChatParticipants(): Promise<void> {
+    await this.participants.loadFromFolder(this.chatParticipantsFolder);
+  }
+
+  public startChatHandler(): void {
+    this.bot.eventManager.registerEvent(
+      LichobiEvent({
+        name: "chat-handler",
+        event: Events.MessageCreate,
+        handler: async (message) => {
+          if (message.author.bot) {
+            return;
+          }
+          const { channel } = message;
+          if (!channel.isSendable()) {
+            return;
+          }
+          const prefix = await this.bot.prefixManager.getCommandPrefix(message);
+          if (message.content.startsWith(prefix)) {
+            // command manager will handle this
+            return;
+          }
+
+          const participants = this.participants.getAll();
+
+          for (const participant of participants) {
+            try {
+              const shouldRespond = await participant.shouldRespond(message);
+              if (!shouldRespond) {
+                continue;
+              }
+              this.bot.logger.info(
+                `${participant.getBaseChatParticipantData().name} responding to message from ${message.author.tag}`,
+              );
+              const [, response] = await Promise.all([
+                channel.sendTyping(),
+                participant.getResponse(message),
+              ]);
+              await message.reply(response);
+              break;
+            } catch (error) {
+              this.bot.logger.error(
+                `Error in chat participant ${participant.getBaseChatParticipantData().name}:`,
+                error,
+              );
+            }
+          }
+        },
+      }),
+    );
+  }
+}

--- a/src/framework/chatManager/chatManager.ts
+++ b/src/framework/chatManager/chatManager.ts
@@ -57,6 +57,7 @@ export class ChatManager {
                 participant.getResponse(message),
               ]);
               await message.reply(response);
+              // Only one chat participant should respond to one message
               break;
             } catch (error) {
               this.bot.logger.error(

--- a/src/framework/chatManager/chatRegistry.ts
+++ b/src/framework/chatManager/chatRegistry.ts
@@ -1,0 +1,132 @@
+import { readdirSync } from "fs";
+import path from "path";
+import { Bot } from "../bot.js";
+import {
+  BaseChatParticipant,
+  isChatParticipantConstructor,
+} from "../chatParticipant/index.js";
+
+export class ChatRegistry {
+  private static readonly ValidExtensions = [".js", ".mjs", ".cjs", ".ts"];
+  private readonly bot: Bot<true>;
+  private readonly participants = new Map<string, BaseChatParticipant>();
+
+  constructor(bot: Bot<true>) {
+    this.bot = bot;
+  }
+
+  public async register(chatParticipant: BaseChatParticipant): Promise<void> {
+    const participantName = chatParticipant
+      .getBaseChatParticipantData()
+      .name.toLowerCase();
+    if (this.participants.has(participantName)) {
+      this.bot.logger.warn(
+        `Chat Participant ${participantName} is already registered. Skipping registration.`,
+      );
+      return;
+    }
+    this.participants.set(participantName, chatParticipant);
+    this.bot.logger.info(`Registered chat participant ${participantName}`);
+    await chatParticipant.setup?.();
+  }
+
+  public async loadFromFolder(folderPath: string): Promise<void> {
+    await this.loadChatParticipantsRecursive(folderPath);
+  }
+
+  private async loadChatParticipantsRecursive(
+    folderPath: string,
+  ): Promise<void> {
+    const items = readdirSync(folderPath, { withFileTypes: true });
+
+    await Promise.all(
+      items.map(async (item) => {
+        const fullPath = path.join(folderPath, item.name);
+
+        if (item.isDirectory()) {
+          await this.loadChatParticipantsRecursive(fullPath);
+        } else if (
+          item.isFile() &&
+          ChatRegistry.ValidExtensions.includes(path.extname(item.name))
+        ) {
+          const chatParticipants = await this.importChatParticipant(fullPath);
+          await Promise.all(
+            chatParticipants.map((chatParticipant) =>
+              this.register(chatParticipant),
+            ),
+          );
+        }
+      }),
+    );
+  }
+
+  private async importChatParticipant(
+    filePath: string,
+  ): Promise<BaseChatParticipant[]> {
+    this.bot.logger.debug(`Importing chat participants from ${filePath}`);
+    try {
+      // Convert to file URL for proper module resolution
+      const importPath = `file://${filePath}`;
+      const module = await import(importPath);
+
+      if (!this.isValidModule(module)) {
+        this.bot.logger.warn(
+          `Skipping invalid module at ${filePath}. Expected a valid ES module, got ${typeof module}`,
+        );
+        return [];
+      }
+
+      const chatParticipants: BaseChatParticipant[] = [];
+
+      const potentialChatParticipants = Object.values(module);
+      for (const exportedValue of potentialChatParticipants) {
+        if (!isChatParticipantConstructor(exportedValue)) {
+          continue;
+        }
+        try {
+          const chatParticipant = new exportedValue(this.bot);
+          chatParticipants.push(chatParticipant);
+        } catch (error) {
+          this.bot.logger.error(
+            `Failed to instantiate chat participant from ${filePath}:`,
+            error,
+          );
+        }
+      }
+
+      if (chatParticipants.length === 0) {
+        this.bot.logger.warn(`No valid chat participants found in ${filePath}`);
+        return [];
+      }
+
+      return chatParticipants;
+    } catch (error) {
+      this.bot.logger.error(
+        `Error loading chat participants from ${filePath}:`,
+        error,
+      );
+      return [];
+    }
+  }
+
+  private isValidModule(module: unknown): module is Record<string, unknown> {
+    return (
+      typeof module === "object" &&
+      module !== null &&
+      !Array.isArray(module) &&
+      Object.entries(module as object).length > 0
+    );
+  }
+
+  public getAll(): BaseChatParticipant[] {
+    return Array.from(this.participants.values()).sort(
+      (a, b) =>
+        b.getBaseChatParticipantData().priority -
+        a.getBaseChatParticipantData().priority,
+    );
+  }
+
+  public get(name: string): BaseChatParticipant | undefined {
+    return this.participants.get(name);
+  }
+}

--- a/src/framework/chatManager/index.ts
+++ b/src/framework/chatManager/index.ts
@@ -1,4 +1,3 @@
 export { ChatManager } from "./chatManager.js";
 export type { ChatManagerOptions } from "./chatManager.js";
 export { ChatRegistry } from "./chatRegistry.js";
-

--- a/src/framework/chatManager/index.ts
+++ b/src/framework/chatManager/index.ts
@@ -1,0 +1,4 @@
+export { ChatManager } from "./chatManager.js";
+export type { ChatManagerOptions } from "./chatManager.js";
+export { ChatRegistry } from "./chatRegistry.js";
+

--- a/src/framework/chatParticipant/base.ts
+++ b/src/framework/chatParticipant/base.ts
@@ -35,4 +35,3 @@ export function ChatParticipant(
 }
 
 export type BaseChatParticipantClass = ReturnType<typeof ChatParticipant>;
-

--- a/src/framework/chatParticipant/base.ts
+++ b/src/framework/chatParticipant/base.ts
@@ -1,0 +1,38 @@
+import { Awaitable, Message } from "discord.js";
+import { Bot } from "../bot.js";
+
+type BaseChatParticipantData = {
+  name: string;
+  description: string;
+  priority: number;
+};
+
+export abstract class BaseChatParticipant {
+  protected readonly bot: Bot<true>;
+
+  constructor(bot: Bot<true>) {
+    this.bot = bot;
+  }
+
+  public setup?(): Awaitable<void> {}
+
+  public abstract getBaseChatParticipantData(): BaseChatParticipantData;
+
+  public abstract shouldRespond(message: Message): Promise<boolean>;
+
+  public abstract getResponse(message: Message): Promise<string>;
+}
+
+export function ChatParticipant(
+  baseChatParticipantData: BaseChatParticipantData,
+) {
+  abstract class ExtendedBaseChatParticipant extends BaseChatParticipant {
+    public override getBaseChatParticipantData(): BaseChatParticipantData {
+      return baseChatParticipantData;
+    }
+  }
+  return ExtendedBaseChatParticipant;
+}
+
+export type BaseChatParticipantClass = ReturnType<typeof ChatParticipant>;
+

--- a/src/framework/chatParticipant/index.ts
+++ b/src/framework/chatParticipant/index.ts
@@ -1,0 +1,13 @@
+import { ConcreteConstructor } from "../utils/types.js";
+import { BaseChatParticipant } from "./base.js";
+
+export * from "./base.js";
+
+export function isChatParticipantConstructor(
+  value: unknown,
+): value is ConcreteConstructor<typeof BaseChatParticipant> {
+  return (
+    typeof value === "function" &&
+    value.prototype instanceof BaseChatParticipant
+  );
+}

--- a/src/framework/command/index.ts
+++ b/src/framework/command/index.ts
@@ -22,6 +22,7 @@ import {
   UserContextMenuCommandMixin,
   UserContextMenuCommandMixinClass,
 } from "./userContextMenuCommandMixin.js";
+import { ConcreteConstructor } from "../utils/types.js";
 
 export { BaseCommand } from "./base.js";
 export { BaseChatInputCommandMixin } from "./chatInputCommandMixin.js";
@@ -80,11 +81,6 @@ export type LichobiCommandTypeToClassMap = {
 export function isLichobiCommand(value: unknown): value is BaseCommand {
   return hasMixin(value, BaseCommand);
 }
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ConcreteConstructor<T extends abstract new (...args: any[]) => any> = new (
-  ...args: ConstructorParameters<T>
-) => InstanceType<T>;
 
 export function isLichobiCommandConstructor(
   value: unknown,

--- a/src/framework/commandManager/commandManager.ts
+++ b/src/framework/commandManager/commandManager.ts
@@ -19,7 +19,6 @@ import { CommandRegistry } from "./commandRegistry.js";
 
 export type CommandManagerOptions = {
   commandsFolder: string;
-  defaultPrefix: string;
   devGuildId?: Snowflake | null;
 };
 
@@ -27,14 +26,12 @@ export class CommandManager {
   private readonly bot: Bot<true>;
   private readonly commandsFolder: string;
   public readonly commands: CommandRegistry;
-  private readonly defaultPrefix: string;
   private readonly devGuildId?: Snowflake;
 
   constructor(bot: Bot<true>, options: CommandManagerOptions) {
     this.bot = bot;
     this.commands = new CommandRegistry(bot);
     this.commandsFolder = options.commandsFolder;
-    this.defaultPrefix = options.defaultPrefix;
     if (options.devGuildId) this.devGuildId = options.devGuildId;
   }
 
@@ -157,7 +154,7 @@ export class CommandManager {
           if (message.author.bot) {
             return;
           }
-          const prefix = await this.getLegacyMessagePrefix();
+          const prefix = await this.bot.prefixManager.getCommandPrefix(message);
           if (!message.content.startsWith(prefix)) {
             return;
           }
@@ -191,10 +188,6 @@ export class CommandManager {
         },
       }),
     );
-  }
-
-  private async getLegacyMessagePrefix(): Promise<string> {
-    return this.defaultPrefix; // TODO: make this configurable per guild, maybe a prefix manager?
   }
 
   private extractCommandAndArgsFromMessage(

--- a/src/framework/commandManager/commandRegistry.ts
+++ b/src/framework/commandManager/commandRegistry.ts
@@ -1,4 +1,3 @@
-import { Bot, LichobiError } from "#lichobi/framework";
 import {
   ApplicationCommandDataResolvable,
   ApplicationCommandOptionType,
@@ -9,12 +8,14 @@ import {
 } from "discord.js";
 import { readdirSync } from "fs";
 import path from "path";
+import { Bot } from "../bot.js";
 import {
   BaseCommand,
   isLichobiCommandConstructor,
   LichobiCommandType,
   LichobiCommandTypeToClassMap,
 } from "../command/index.js";
+import { LichobiError } from "../errors.js";
 
 export class CommandRegistry {
   private static readonly ValidExtensions = [".js", ".mjs", ".cjs", ".ts"];

--- a/src/framework/prefixManager/index.ts
+++ b/src/framework/prefixManager/index.ts
@@ -1,0 +1,2 @@
+export * from "./prefixManager.js";
+

--- a/src/framework/prefixManager/index.ts
+++ b/src/framework/prefixManager/index.ts
@@ -1,2 +1,1 @@
 export * from "./prefixManager.js";
-

--- a/src/framework/prefixManager/prefixManager.ts
+++ b/src/framework/prefixManager/prefixManager.ts
@@ -1,0 +1,23 @@
+import { Message } from "discord.js";
+import { Bot } from "../bot.js";
+
+export type PrefixManagerOptions = {
+  defaultPrefix: string;
+};
+
+export class PrefixManager {
+  private readonly bot: Bot<true>;
+  private readonly defaultPrefix: string;
+
+  constructor(bot: Bot<true>, options: PrefixManagerOptions) {
+    this.bot = bot;
+    this.defaultPrefix = options.defaultPrefix;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public async getCommandPrefix(message: Message): Promise<string> {
+    // TODO: Add support for user specific (?) / guild specific prefixes.
+    return this.defaultPrefix;
+  }
+}
+

--- a/src/framework/prefixManager/prefixManager.ts
+++ b/src/framework/prefixManager/prefixManager.ts
@@ -20,4 +20,3 @@ export class PrefixManager {
     return this.defaultPrefix;
   }
 }
-

--- a/src/framework/utils/types.ts
+++ b/src/framework/utils/types.ts
@@ -1,0 +1,4 @@
+export type ConcreteConstructor<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  T extends abstract new (...args: any[]) => any,
+> = new (...args: ConstructorParameters<T>) => InstanceType<T>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,9 +18,11 @@ const bot = new Bot({
   loggerOptions: {
     minLogLevel: config.minLogLevel ?? "info",
   },
+  prefixManagerOptions: {
+    defaultPrefix: config.defaultPrefix || "!",
+  },
   commandManagerOptions: {
     commandsFolder: join(__dirname, "commands"),
-    defaultPrefix: config.defaultPrefix || "!",
     devGuildId: config.devGuildId || null,
   },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,9 @@ const bot = new Bot({
     commandsFolder: join(__dirname, "commands"),
     devGuildId: config.devGuildId || null,
   },
+  chatManagerOptions: {
+    chatParticipantsFolder: join(__dirname, "chatParticipants"),
+  },
 });
 
 bot.bootUp(config.discordBotToken);


### PR DESCRIPTION
- Add ability for the discord bot to chat in a channel like a normal user.
- Multiple Chat Managers can be defined which control when and how the bot responds to texts in a channel.
- Added a placeholder Prefix manager to share the prefix logic between Command and Chat manager. The chat manager will not respond if the message could be a legacy message command (starts with the prefix).